### PR TITLE
Fix: workaround for symlinks issue in wercker

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -6,6 +6,9 @@ dev:
 build:
     steps:
       - script:
+        name: symlinks workaround
+        code: rm -rf _build/*
+      - script:
         name: run test suite
         code: make test
       - script:


### PR DESCRIPTION
Today in build pipeline wercker expands symlinks with the full _Host_ OS path
(wercker bug).
As rebar3 uses symilnks in the _build/ directory, `rebar3 dialyzer` cannot find
src files and the build step fails. Updating the _build/ contents withing the
flow helps.
