### PR TITLE
FIX: Timespan parsing

### DIFF
--- a/src/genlib_format.erl
+++ b/src/genlib_format.erl
@@ -371,7 +371,7 @@ parse_datetime_iso8601_tz(Bin) ->
 parse_timespan(DeadlineStr) ->
     %% deadline string like '1ms', '30m', '1.5m' etc
     case re:run(DeadlineStr, <<"^(\\d+\\.\\d+|\\d+)([a-z]+)$">>, [global, {capture, all_but_first, binary}]) of
-        {match, [NumberStr, Unit]} ->
+        {match, [[NumberStr, Unit]]} ->
             Number = genlib:to_float(NumberStr),
             parse_timespan(Number, Unit);
         _Other ->

--- a/test/genlib_format_tests.erl
+++ b/test/genlib_format_tests.erl
@@ -125,12 +125,12 @@ uuid_to_bstring_test_() ->
           )
     ].
 
--spec parse_timespan_test() -> [testcase()].
-parse_timespan_test() ->
+-spec parse_timespan_test_() -> [testcase()].
+parse_timespan_test_() ->
     [
-        ?_assertMatch({ok, {_, _}}, genlib_format:parse_timespan(<<"15s">>)),
-        ?_assertMatch({ok, {_, _}}, genlib_format:parse_timespan(<<"15m">>)),
-        ?_assertMatch({ok, {_, _}}, genlib_format:parse_timespan(<<"1.5m">>)),
-        ?_assertError(badarg,       genlib_format:parse_timespan(<<"15h">>))
+        ?_assertEqual(15 * 1000,                              genlib_format:parse_timespan(<<"15s">>)),
+        ?_assertEqual(15 * 60 * 1000,                         genlib_format:parse_timespan(<<"15m">>)),
+        ?_assertEqual(erlang:round(1.5 * 60 * 1000),          genlib_format:parse_timespan(<<"1.5m">>)),
+        ?_assertError({badarg, {invalid_time_unit, <<"h">>}}, genlib_format:parse_timespan(<<"15h">>))
     ].
     


### PR DESCRIPTION
Нашел и исправил 3 ошибки, допущенные мной в #17 :
* Неправильный матчинг на результат `re:run/3`.
* Неверное название теста на этот самый матчинг, из-за которого тест не выполнялся.
* Неверный матчинг в тесте парсинга