### PR TITLE
Use semantic versioning in app.src

### DIFF
--- a/src/genlib.app.src
+++ b/src/genlib.app.src
@@ -1,6 +1,6 @@
 {application, genlib, [
     {description, "A collection of general implementations of common activities"},
-    {vsn, "0.1"},
+    {vsn, "0.1.0"},
     {registered, []},
     {applications, [
         kernel,


### PR DESCRIPTION
```
Unchecked dependencies for environment dev:
* genlib (https://github.com/rbkmoney/genlib.git)
  the app file specified a non-Semantic Versioning format: "0.1". Mix can only match the requirement ">= 0.0.0" against semantic versions. Please fix the application version or use a regular expression as a requirement to match against any version
** (Mix) Can't continue due to errors on dependencies
```