### PR TITLE
Track pmap timeout through a fuse process

### DIFF
--- a/src/genlib_pmap.erl
+++ b/src/genlib_pmap.erl
@@ -13,6 +13,8 @@
     proc_limit => pos_integer()
 }.
 
+-define(DEFAULT_SAFEMAP_TIMEOUT, 5000).
+
 -spec map(fun((A) -> B), [A]) ->
     [B].
 -spec map(fun((A) -> B), [A], opts()) ->
@@ -52,7 +54,7 @@ safemap(F, L, Opts) ->
 
 spawn_fuse(Opts) ->
     Pid = erlang:self(),
-    Timeout = maps:get(timeout, Opts, 5000),
+    Timeout = maps:get(timeout, Opts, ?DEFAULT_SAFEMAP_TIMEOUT),
     erlang:spawn(fuse(Pid, Timeout)).
 
 -spec fuse(pid(), timeout()) ->

--- a/src/genlib_pmap.erl
+++ b/src/genlib_pmap.erl
@@ -13,6 +13,8 @@
     proc_limit => pos_integer()
 }.
 
+ -dialyzer({nowarn_function, [spawn_fuse/1]}).
+
 -spec map(fun((A) -> B), [A]) ->
     [B].
 -spec map(fun((A) -> B), [A], opts()) ->
@@ -55,6 +57,8 @@ spawn_fuse(Opts) ->
     Timeout = maps:get(timeout, Opts, 5000),
     erlang:spawn(fun () -> fuse(Pid, Timeout) end).
 
+-spec fuse(pid(), timeout()) ->
+    no_return().
 fuse(Pid, Timeout) ->
     _Was = erlang:process_flag(trap_exit, true),
     MRef = erlang:monitor(process, Pid),

--- a/src/genlib_pmap.erl
+++ b/src/genlib_pmap.erl
@@ -34,44 +34,69 @@ safemap(F, L) ->
     safemap(F, L, #{}).
 
 safemap(F, L, Opts) ->
-    case maps:get(proc_limit, Opts, undefined) of
+    Fuse = spawn_fuse(Opts),
+    Results = case maps:get(proc_limit, Opts, undefined) of
         undefined ->
-            collect(fun collect_one/3, lists:map(executor_one(F), L), Opts);
+            collect(fun collect_one/3, lists:map(executor_one(F, Fuse), L));
         Limit ->
             Size = erlang:length(L),
             if
                 Limit >= Size ->
-                    collect(fun collect_one/3, lists:map(executor_one(F), L), Opts);
+                    collect(fun collect_one/3, lists:map(executor_one(F, Fuse), L));
                 Limit < Size ->
-                    collect(fun collect_many/3, distribute(F, L, Size, Limit, 0), Opts)
+                    collect(fun collect_many/3, distribute(F, Fuse, L, Size, Limit, 0))
             end
+    end,
+    _ = erlang:exit(Fuse, normal),
+    Results.
+
+spawn_fuse(Opts) ->
+    Pid = erlang:self(),
+    Timeout = maps:get(timeout, Opts, 5000),
+    erlang:spawn(fun () -> fuse(Pid, Timeout) end).
+
+fuse(Pid, Timeout) ->
+    _Was = erlang:process_flag(trap_exit, true),
+    MRef = erlang:monitor(process, Pid),
+    receive
+        {'EXIT', Pid, Reason} ->
+            exit(Reason);
+        {'DOWN', MRef, process, Pid, Reason} ->
+            exit(Reason)
+    after Timeout ->
+        exit(timeout)
     end.
 
-distribute(_, [], _Size, Limit, Limit) ->
+distribute(_, _, [], _Size, Limit, Limit) ->
     [];
-distribute(F, List, Size, Limit, I) when I < Limit ->
+distribute(F, Fuse, List, Size, Limit, I) when I < Limit ->
     Ns = compute_nth_slice(I, Size, Limit),
     {Slice, Rest} = lists:split(Ns, List),
-    [spawn_executor(fun execute_many/2, F, Slice, Ns) | distribute(F, Rest, Size, Limit, I + 1)].
+    Executor = spawn_executor(fun execute_many/2, F, Fuse, Slice, Ns),
+    [Executor | distribute(F, Fuse, Rest, Size, Limit, I + 1)].
 
 compute_nth_slice(N, Size, Limit) ->
     (Size * (N + 1) div Limit) - (Size * N div Limit).
 
-executor_one(F) ->
+executor_one(F, Fuse) ->
     fun (E) ->
-        spawn_executor(fun execute_one/2, F, E, 1)
+        spawn_executor(fun execute_one/2, F, Fuse, E, 1)
     end.
 
-spawn_executor(Executor, F, E, Extra) ->
+spawn_executor(Executor, F, Fuse, E, Extra) ->
     Pid = erlang:self(),
     Ref = erlang:make_ref(),
-    % NOTE
-    % It should be safe _unless_ user supplied function decides to kill `self()`.
-    WorkerPid = erlang:spawn_link(fun () ->
+    WorkerPidRef = erlang:spawn_monitor(fun () ->
+        % NOTE
+        % If the fuse process is already dead at the time of linking (when the
+        % timeout value was very small for example) worker will die right away
+        % and the ERTS will emit appropriate error report. This will make some
+        % noise and I can't seem to find a way to silence it.
+        _ = erlang:link(Fuse),
         _ = Pid ! {Ref, Executor(F, E)},
         ok
     end),
-    {{WorkerPid, Ref}, Extra}.
+    {{WorkerPidRef, Ref}, Extra}.
 
 -spec execute_one(fun((A) -> B), A) -> result(B).
 
@@ -87,55 +112,24 @@ execute_one(F, E) ->
 execute_many(F, L) ->
     {many, lists:foldl(fun (E, Acc) -> [execute_one(F, E) | Acc] end, [], L)}.
 
-collect(Collector, Workers, Opts) ->
-    Timeout = maps:get(timeout, Opts, 5000),
-    Deadline = shift_timeout(Timeout, nowms()),
-    Results = case Deadline of
-        infinity ->
-            await(Collector, Workers, []);
-        Deadline ->
-            await_deadline(Deadline, Collector, Workers, [], [])
-    end,
+collect(Collector, Workers) ->
+    Results = await(Collector, Workers, []),
     lists:reverse(Results).
 
-await(Collector, [{{_, Ref}, Extra} | WorkersLeft], Results) ->
+await(Collector, [{{{WorkerPid, MRef}, Ref}, Extra} | WorkersLeft], Results) ->
     receive
         {Ref, Result} ->
+            _ = erlang:demonitor(MRef, [flush]),
+            await(Collector, WorkersLeft, Collector(Result, Extra, Results));
+        {'DOWN', MRef, process, WorkerPid, Reason} ->
+            Result = case Reason of
+                {noproc, _} -> timeout;
+                _           -> Reason
+            end,
             await(Collector, WorkersLeft, Collector(Result, Extra, Results))
     end;
 await(_Collector, [], Results) ->
     Results.
-
-await_deadline(Deadline, Collector, [{{PID, Ref}, Extra} | WorkersLeft], Results, Stuck) ->
-    receive
-        {Ref, Result} ->
-            await_deadline(Deadline, Collector, WorkersLeft, Collector(Result, Extra, Results), Stuck)
-    after max(0, shift_timeout(Deadline, -nowms())) ->
-        await_deadline(Deadline, Collector, WorkersLeft, Collector(timeout, Extra, Results), [PID | Stuck])
-    end;
-await_deadline(_Deadline, _Collector, [], Results, Stuck) ->
-    ok = discharge(Stuck),
-    Results.
-
-discharge(Stuck = [_ | _]) ->
-    FlagWas = erlang:process_flag(trap_exit, true),
-    ok = lists:foreach(fun (PID) -> erlang:exit(PID, kill) end, Stuck),
-    ok = lists:foreach(fun (PID) -> receive {'EXIT', PID, _Reason} -> ok end end, Stuck),
-    _ = erlang:process_flag(trap_exit, FlagWas),
-    case FlagWas of
-        false -> handle_trapped_exits();
-        true  -> ok
-    end;
-discharge([]) ->
-    ok.
-
-handle_trapped_exits() ->
-    receive
-        {'EXIT', _PID, normal} -> handle_trapped_exits();
-        {'EXIT', _PID, Reason} -> erlang:exit(Reason)
-    after 0 ->
-        ok
-    end.
 
 collect_one(Result = {ok, _}, _, Acc) ->
     [Result | Acc];
@@ -153,17 +147,9 @@ collect_many(timeout, N, Acc) ->
 collect_many(Result, N, Acc) ->
     lists:duplicate(N, {exit, Result, []}) ++ Acc.
 
-shift_timeout(infinity, _) ->
-    infinity;
-shift_timeout(Timeout, V) ->
-    Timeout + V.
-
 replicate({ok, Result}) ->
     Result;
 replicate({error, {C, R, ST}}) ->
     erlang:raise(C, R, ST);
 replicate(timeout) ->
     error(timeout).
-
-nowms() ->
-    erlang:monotonic_time(millisecond).


### PR DESCRIPTION
This should make code simpler and help with potential races and leftovers in mailbox.