### PR TITLE
feat: Add bunch of useful functions for seqs

### DIFF
--- a/src/genlib_list.erl
+++ b/src/genlib_list.erl
@@ -26,6 +26,10 @@ compact(List) ->
         List
     ).
 
+%% @doc Wrap given term into a list.
+%% If a list is given, this list is returned.
+%% If undefined is passed, empty list is returned
+
 -spec wrap(undefined | list(T) | T) -> [] | list(T) when T :: term().
 wrap(undefined) ->
     [];
@@ -34,6 +38,9 @@ wrap(List) when is_list(List) ->
 wrap(Term) ->
     [Term].
 
+%% @doc Group values in a given list by result of KeyFun.
+%% The result is a map, where keys are results of KeyFun, and values are list of values of original list
+%% that result in such key.
 -spec group_by(fun((T) -> K), list(T)) -> #{K := list(T)} when T :: term(), K :: term().
 group_by(KeyFun, List) ->
     lists:foldl(
@@ -46,6 +53,8 @@ group_by(KeyFun, List) ->
         List
     ).
 
+%% @doc Like lists:foldl, but can be stopped amid the traversal of a list.
+%% Function must return {cont, NewAcc} to continue folding the list, or {halt, FinalAcc} to stop immediately.
 -spec foldl_while(fun((T, Acc) -> {cont, Acc} | {halt, Acc}), Acc, list(T)) -> Acc when T :: term(), Acc :: term().
 foldl_while(Fun, Acc, List) when is_function(Fun, 2), is_list(List) ->
     do_foldl_while(Fun, Acc, List).

--- a/src/genlib_list.erl
+++ b/src/genlib_list.erl
@@ -3,6 +3,10 @@
 %% API
 -export([join/2]).
 -export([compact/1]).
+-export([wrap/1]).
+-export([group_by/2]).
+-export([foldl_while/3]).
+-export([orderless_equal/2]).
 
 %%
 %% API
@@ -21,3 +25,41 @@ compact(List) ->
         end,
         List
     ).
+
+-spec wrap(undefined | list(T) | T) -> [] | list(T) when T :: term().
+wrap(undefined) ->
+    [];
+wrap(List) when is_list(List) ->
+    List;
+wrap(Term) ->
+    [Term].
+
+-spec group_by(fun((T) -> K), list(T)) -> #{K := list(T)} when T :: term(), K :: term().
+group_by(KeyFun, List) ->
+    lists:foldl(
+        fun(Elt, Acc) ->
+            Key = KeyFun(Elt),
+            GroupList = maps:get(Key, Acc, []),
+            maps:put(Key, [Elt | GroupList], Acc)
+        end,
+        #{},
+        List
+    ).
+
+-spec foldl_while(fun((T, Acc) -> {cont, Acc} | {halt, Acc}), Acc, list(T)) -> Acc when T :: term(), Acc :: term().
+foldl_while(Fun, Acc, List) when is_function(Fun, 2), is_list(List) ->
+    do_foldl_while(Fun, Acc, List).
+
+do_foldl_while(_Fun, Acc, []) ->
+    Acc;
+do_foldl_while(Fun, Acc, [Elem | Rest]) ->
+    case Fun(Elem, Acc) of
+        {cont, NextAcc} ->
+            do_foldl_while(Fun, NextAcc, Rest);
+        {halt, FinalAcc} ->
+            FinalAcc
+    end.
+
+-spec orderless_equal(list(), list()) -> boolean().
+orderless_equal(List1, List2) ->
+    (List1 -- List2) =:= (List2 -- List1).

--- a/src/genlib_list.erl
+++ b/src/genlib_list.erl
@@ -72,15 +72,3 @@ do_foldl_while(Fun, Acc, [Elem | Rest]) ->
 -spec orderless_equal(list(), list()) -> boolean().
 orderless_equal(List1, List2) ->
     (List1 -- List2) =:= (List2 -- List1).
-
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
-
--spec test() -> _.
-
--spec wrap_empty_list_for_undefined_test() -> _.
-
-wrap_empty_list_for_undefined_test() ->
-    ?assertEqual(genlib_list:wrap(undefined), []).
-
--endif.

--- a/src/genlib_list.erl
+++ b/src/genlib_list.erl
@@ -72,3 +72,15 @@ do_foldl_while(Fun, Acc, [Elem | Rest]) ->
 -spec orderless_equal(list(), list()) -> boolean().
 orderless_equal(List1, List2) ->
     (List1 -- List2) =:= (List2 -- List1).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-spec test() -> _.
+
+-spec wrap_empty_list_for_undefined_test() -> _.
+
+wrap_empty_list_for_undefined_test() ->
+    ?assertEqual(genlib_list:wrap(undefined), []).
+
+-endif.

--- a/src/genlib_map.erl
+++ b/src/genlib_map.erl
@@ -144,6 +144,8 @@ diff(Map, Since) ->
         Since
     ).
 
+%% @doc Like lists:foldl, but can be stopped amid the traversal of a map.
+%% Function must return {cont, NewAcc} to continue folding the list, or {halt, FinalAcc} to stop immediately.
 -spec fold_while(fun((K, V, Acc) -> {cont, Acc} | {halt, Acc}), Acc, #{K => V}) -> Acc when
     K :: term(), V :: term(), Acc :: term().
 fold_while(Fun, Acc, Map) when is_function(Fun, 3) and is_map(Map) ->

--- a/src/genlib_map.erl
+++ b/src/genlib_map.erl
@@ -161,3 +161,21 @@ do_fold_while(Fun, Acc, Iter) ->
                 {cont, NextAcc} -> do_fold_while(Fun, NextAcc, NextIter)
             end
     end.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+-spec test() -> _.
+
+-spec fold_while_does_nothing_for_empty_map_test() -> _.
+
+fold_while_does_nothing_for_empty_map_test() ->
+    genlib_map:fold_while(
+        fun(_, _, _) ->
+            throw(blow_up)
+        end,
+        true,
+        #{}
+    ).
+
+-endif.

--- a/src/genlib_map.erl
+++ b/src/genlib_map.erl
@@ -17,6 +17,7 @@
 -export([binarize/1]).
 -export([binarize/2]).
 -export([diff/2]).
+-export([fold_while/3]).
 
 %%
 
@@ -142,3 +143,19 @@ diff(Map, Since) ->
         Map,
         Since
     ).
+
+-spec fold_while(fun((K, V, Acc) -> {cont, Acc} | {halt, Acc}), Acc, #{K => V}) -> Acc when
+    K :: term(), V :: term(), Acc :: term().
+fold_while(Fun, Acc, Map) when is_function(Fun, 3) and is_map(Map) ->
+    do_fold_while(Fun, Acc, maps:iterator(Map)).
+
+do_fold_while(Fun, Acc, Iter) ->
+    case maps:next(Iter) of
+        none ->
+            Acc;
+        {K, V, NextIter} ->
+            case Fun(K, V, Acc) of
+                {halt, FinalAcc} -> FinalAcc;
+                {cont, NextAcc} -> do_fold_while(Fun, NextAcc, NextIter)
+            end
+    end.

--- a/src/genlib_map.erl
+++ b/src/genlib_map.erl
@@ -161,21 +161,3 @@ do_fold_while(Fun, Acc, Iter) ->
                 {cont, NextAcc} -> do_fold_while(Fun, NextAcc, NextIter)
             end
     end.
-
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
-
--spec test() -> _.
-
--spec fold_while_does_nothing_for_empty_map_test() -> _.
-
-fold_while_does_nothing_for_empty_map_test() ->
-    genlib_map:fold_while(
-        fun(_, _, _) ->
-            throw(blow_up)
-        end,
-        true,
-        #{}
-    ).
-
--endif.

--- a/src/genlib_map.erl
+++ b/src/genlib_map.erl
@@ -144,7 +144,7 @@ diff(Map, Since) ->
         Since
     ).
 
-%% @doc Like lists:foldl, but can be stopped amid the traversal of a map.
+%% @doc Like maps:fold, but can be stopped amid the traversal of a map.
 %% Function must return {cont, NewAcc} to continue folding the list, or {halt, FinalAcc} to stop immediately.
 -spec fold_while(fun((K, V, Acc) -> {cont, Acc} | {halt, Acc}), Acc, #{K => V}) -> Acc when
     K :: term(), V :: term(), Acc :: term().

--- a/test/genlib_list_tests.erl
+++ b/test/genlib_list_tests.erl
@@ -1,0 +1,10 @@
+-module(genlib_list_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-spec test() -> _.
+
+-spec wrap_empty_list_for_undefined_test() -> _.
+
+wrap_empty_list_for_undefined_test() ->
+    ?assertEqual(genlib_list:wrap(undefined), []).

--- a/test/genlib_map_tests.erl
+++ b/test/genlib_map_tests.erl
@@ -48,3 +48,13 @@ diff_test_() ->
         ?_assertEqual(#{this_is => 'undefined'}, genlib_map:diff(#{this_is => 'undefined'}, #{this_is => 'not'})),
         ?_assertEqual(#{this_is => 'not'}, genlib_map:diff(#{this_is => 'not'}, #{this_is => 'undefined'}))
     ].
+
+-spec fold_while_does_nothing_for_empty_map_test() -> _.
+fold_while_does_nothing_for_empty_map_test() ->
+    genlib_map:fold_while(
+        fun(_, _, _) ->
+            throw(blow_up)
+        end,
+        true,
+        #{}
+    ).

--- a/test/prop_genlib_list.erl
+++ b/test/prop_genlib_list.erl
@@ -7,13 +7,10 @@ prop_wrap() ->
     ?FORALL(
         Term,
         term(),
-        case Term of
-            undefined ->
-                [] =:= genlib_list:wrap(Term);
-            List when is_list(List) ->
-                List =:= genlib_list:wrap(Term);
-            _ ->
-                [Term] =:= genlib_list:wrap(Term)
+        begin
+            Result = genlib_list:wrap(Term),
+            %% List must stay the same, anything else (except `undefined`) ­
+            (is_list(Term) and (Result == Term)) or is_list(Result)
         end
     ).
 

--- a/test/prop_genlib_list.erl
+++ b/test/prop_genlib_list.erl
@@ -49,29 +49,37 @@ prop_orderless_equal() ->
         genlib_list:orderless_equal(List1, List2) == (lists:sort(List1) == lists:sort(List2))
     ).
 
--spec prop_group_by() -> proper:test().
-prop_group_by() ->
+-spec prop_group_by_has_same_values() -> proper:test().
+prop_group_by_has_same_values() ->
     ?FORALL(
         List,
         list(),
         begin
             Result = genlib_list:group_by(fun(X) -> X end, List),
             AllValues = lists:flatmap(fun(X) -> X end, maps:values(Result)),
-            SameValues = lists:sort(List) =:= lists:sort(AllValues),
 
-            CorrectlyGrouped =
-                maps:fold(
-                    fun
-                        (_, _, false) ->
-                            false;
-                        (Key, Values, true) ->
-                            Filtered = lists:filter(fun(K) -> K =:= Key end, List),
-                            genlib_list:orderless_equal(Values, Filtered)
-                    end,
-                    true,
-                    Result
-                ),
+            lists:sort(List) =:= lists:sort(AllValues)
+        end
+    ).
 
-            SameValues and CorrectlyGrouped
+-spec prop_group_by_groups_correctly() -> proper:test().
+prop_group_by_groups_correctly() ->
+    ?FORALL(
+        List,
+        list(),
+        begin
+            Result = genlib_list:group_by(fun(X) -> X end, List),
+
+            maps:fold(
+                fun
+                    (_, _, false) ->
+                        false;
+                    (Key, Values, true) ->
+                        Filtered = lists:filter(fun(K) -> K =:= Key end, List),
+                        genlib_list:orderless_equal(Values, Filtered)
+                end,
+                true,
+                Result
+            )
         end
     ).

--- a/test/prop_genlib_list.erl
+++ b/test/prop_genlib_list.erl
@@ -1,0 +1,80 @@
+-module(prop_genlib_list).
+
+-include_lib("proper/include/proper.hrl").
+
+-spec prop_wrap() -> proper:test().
+prop_wrap() ->
+    ?FORALL(
+        Term,
+        term(),
+        case Term of
+            undefined ->
+                [] =:= genlib_list:wrap(Term);
+            List when is_list(List) ->
+                List =:= genlib_list:wrap(Term);
+            _ ->
+                [Term] =:= genlib_list:wrap(Term)
+        end
+    ).
+
+-spec prop_foldl_while() -> proper:test().
+prop_foldl_while() ->
+    ?FORALL(
+        [Int1, Int2],
+        [pos_integer(), pos_integer()],
+        begin
+            SeqLength = max(Int1, Int2),
+            Limit = min(Int1, Int2),
+
+            Seq = lists:seq(1, SeqLength),
+            SimpleResult = length(lists:filter(fun(E) -> E =< Limit end, Seq)),
+            FoldlWhileResult =
+                genlib_list:foldl_while(
+                    fun(E, Acc) ->
+                        NewAcc = Acc + 1,
+                        case E < Limit of
+                            true -> {cont, NewAcc};
+                            false -> {halt, NewAcc}
+                        end
+                    end,
+                    0,
+                    Seq
+                ),
+            SimpleResult =:= FoldlWhileResult
+        end
+    ).
+
+-spec prop_orderless_equal() -> proper:test().
+prop_orderless_equal() ->
+    ?FORALL(
+        [List1, List2],
+        [list(), list()],
+        genlib_list:orderless_equal(List1, List2) == (lists:sort(List1) == lists:sort(List2))
+    ).
+
+-spec prop_group_by() -> proper:test().
+prop_group_by() ->
+    ?FORALL(
+        List,
+        list(),
+        begin
+            Result = genlib_list:group_by(fun(X) -> X end, List),
+            AllValues = lists:flatmap(fun(X) -> X end, maps:values(Result)),
+            SameValues = lists:sort(List) =:= lists:sort(AllValues),
+
+            CorrectlyGrouped =
+                maps:fold(
+                    fun
+                        (_, _, false) ->
+                            false;
+                        (Key, Values, true) ->
+                            Filtered = lists:filter(fun(K) -> K =:= Key end, List),
+                            genlib_list:orderless_equal(Values, Filtered)
+                    end,
+                    true,
+                    Result
+                ),
+
+            SameValues and CorrectlyGrouped
+        end
+    ).

--- a/test/prop_genlib_map.erl
+++ b/test/prop_genlib_map.erl
@@ -6,11 +6,7 @@
 prop_fold_while() ->
     ?FORALL(
         Map,
-        ?SUCHTHAT(
-            NonEmptyMap,
-            ?LET(KVList, list({term(), term()}), maps:from_list(KVList)),
-            map_size(NonEmptyMap) /= 0
-        ),
+        ?LET(KVList, non_empty(list({term(), term()})), maps:from_list(KVList)),
         begin
             RandomId = rand:uniform(map_size(Map)),
             {RandomKey, RandomValue} = lists:nth(RandomId, maps:to_list(Map)),

--- a/test/prop_genlib_map.erl
+++ b/test/prop_genlib_map.erl
@@ -1,0 +1,35 @@
+-module(prop_genlib_map).
+
+-include_lib("proper/include/proper.hrl").
+
+-spec prop_fold_while() -> proper:test().
+prop_fold_while() ->
+    ?FORALL(
+        Map,
+        ?LET(KVList, list({term(), term()}), maps:from_list(KVList)),
+        begin
+            case map_size(Map) of
+                0 ->
+                    genlib_map:fold_while(
+                        fun(_, _, _) -> throw(blow_up) end,
+                        true,
+                        Map
+                    );
+                Size ->
+                    RandomId = rand:uniform(Size),
+                    {RandomKey, RandomValue} = lists:nth(RandomId, maps:to_list(Map)),
+
+                    Result =
+                        genlib_map:fold_while(
+                            fun
+                                (K, V, _Acc) when K =:= RandomKey -> {halt, V};
+                                (_K, _V, Acc) -> {cont, Acc}
+                            end,
+                            make_ref(),
+                            Map
+                        ),
+
+                    Result =:= RandomValue
+            end
+        end
+    ).

--- a/test/prop_genlib_map.erl
+++ b/test/prop_genlib_map.erl
@@ -6,30 +6,25 @@
 prop_fold_while() ->
     ?FORALL(
         Map,
-        ?LET(KVList, list({term(), term()}), maps:from_list(KVList)),
+        ?SUCHTHAT(
+            NonEmptyMap,
+            ?LET(KVList, list({term(), term()}), maps:from_list(KVList)),
+            map_size(NonEmptyMap) /= 0
+        ),
         begin
-            case map_size(Map) of
-                0 ->
-                    genlib_map:fold_while(
-                        fun(_, _, _) -> throw(blow_up) end,
-                        true,
-                        Map
-                    );
-                Size ->
-                    RandomId = rand:uniform(Size),
-                    {RandomKey, RandomValue} = lists:nth(RandomId, maps:to_list(Map)),
+            RandomId = rand:uniform(map_size(Map)),
+            {RandomKey, RandomValue} = lists:nth(RandomId, maps:to_list(Map)),
 
-                    Result =
-                        genlib_map:fold_while(
-                            fun
-                                (K, V, _Acc) when K =:= RandomKey -> {halt, V};
-                                (_K, _V, Acc) -> {cont, Acc}
-                            end,
-                            make_ref(),
-                            Map
-                        ),
+            Result =
+                genlib_map:fold_while(
+                    fun
+                        (K, V, _Acc) when K =:= RandomKey -> {halt, V};
+                        (_K, _V, Acc) -> {cont, Acc}
+                    end,
+                    make_ref(),
+                    Map
+                ),
 
-                    Result =:= RandomValue
-            end
+            Result =:= RandomValue
         end
     ).


### PR DESCRIPTION
Добавил пару хэлперов для коллекций, без которых тяжело живётся (...после Elixir 😬)

- `lists`:
  - `wrap`: оборачивает терм в лист если уже не
  - `group_by`: на основе `KeyFun` группирует значения списка по ключам в мапу
  - `fold_while`: self-explanatory
- `maps`:
  - `fold_while`: self-explanatory
  
На опыте работы с Эликсирным [`Enum`](https://hexdocs.pm/elixir/Enum.html) могу сказать, что quality of life повышают :)
В том же Enum можно посмотреть, откуда у этого PR ноги растут.